### PR TITLE
Remove execute on native jar file in java.io.tmpdir

### DIFF
--- a/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
+++ b/native/src/main/java/org/jline/nativ/JLineNativeLoader.java
@@ -200,10 +200,8 @@ public class JLineNativeLoader {
                 extractedLckFile.deleteOnExit();
             }
 
-            // Set executable (x) flag to enable Java to load the native library
             extractedLibFile.setReadable(true);
             extractedLibFile.setWritable(true);
-            extractedLibFile.setExecutable(true);
 
             // Check whether the contents are properly copied from the resource folder
             try (InputStream nativeIn = JLineNativeLoader.class.getResourceAsStream(nativeLibraryFilePath)) {


### PR DESCRIPTION
JLine creates a `.so` and a `.so.lck` file when interactively prompting the user for input.
The `.so` file has read,write, and execute permissions set on it.
```
jlinenative-3.25.1-164e07369eff3578-libjlinenative.so
jlinenative-3.25.1-164e07369eff3578-libjlinenative.so.lck
```

These files are created in the directory path set by `java.io.tmpdir` which is typically /tmp or /var/tmp. 
However, these directories are commonly set with `noexec` permissions to conform with security best practices.
https://www.stigviewer.com/stig/red_hat_enterprise_linux_8/2023-12-01/finding/V-230513

When `noexec` option is set, this prevents jline from creating the native lib file and prevents jline from functioning correctly. 

When doing local testing with the permission removed, the native library file was able to be loaded successfully without the execute permissions being set on it. 